### PR TITLE
Make sure to only select ap by signal

### DIFF
--- a/main/uart_nic.c
+++ b/main/uart_nic.c
@@ -49,7 +49,7 @@
 // Externals with no header
 esp_err_t mac_init(void);
 
-#define FW_VERSION 12
+#define FW_VERSION 13
 
 #define SCAN_MAX_STORED_SSIDS 64
 #define SSID_LEN 32
@@ -595,7 +595,7 @@ static void read_wifi_client_message() {
     wifi_config.sta.pmf_cfg.capable = 1;
     wifi_config.sta.scan_method = WIFI_ALL_CHANNEL_SCAN;
     wifi_config.sta.sort_method = WIFI_CONNECT_AP_BY_SIGNAL;
-    
+
     // If scan is in progress we need to stop it manually here to prevent reconnect to previous AP.
     if (scan.in_progress) {
         scan.should_reconnect = false;

--- a/main/uart_nic.c
+++ b/main/uart_nic.c
@@ -593,7 +593,9 @@ static void read_wifi_client_message() {
         wifi_config.sta.threshold.authmode = WIFI_AUTH_WPA2_PSK;
     }
     wifi_config.sta.pmf_cfg.capable = 1;
-
+    wifi_config.sta.scan_method = WIFI_ALL_CHANNEL_SCAN;
+    wifi_config.sta.sort_method = WIFI_CONNECT_AP_BY_SIGNAL;
+    
     // If scan is in progress we need to stop it manually here to prevent reconnect to previous AP.
     if (scan.in_progress) {
         scan.should_reconnect = false;


### PR DESCRIPTION
This solves issue https://github.com/prusa3d/Prusa-Firmware-Buddy/issues/5090 by enforcing to select AP by signal, thus preventing to choose AP with same SSID but weaker signal (which is the case for repeated signals).